### PR TITLE
Fix compile error "expected a type"

### DIFF
--- a/include/GRMustacheTag.h
+++ b/include/GRMustacheTag.h
@@ -23,6 +23,7 @@
 #import <Foundation/Foundation.h>
 #import "GRMustacheAvailabilityMacros.h"
 
+@class GRMustacheContext;
 @class GRMustacheTemplateRepository;
 
 /**


### PR DESCRIPTION
Not entirely sure how this compiled before, but I noticed it failing when including as a CocoaPod with `use_frameworks!`.
